### PR TITLE
Linear Webhooks Router MVP: routing, persistence, retries, logging, and DLQ

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database package initialization."""

--- a/app/db/repository.py
+++ b/app/db/repository.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Mapping:
+    linear_issue_id: str
+    github_owner: str
+    github_repo: str
+    github_issue_number: int
+    content_checksum: str | None = None
+
+
+class MappingRepository:
+    """SQLite-backed repository for Linear↔GitHub issue mappings.
+
+    Storage URL formats supported:
+    - file path to a SQLite database file, e.g., `data/app.db`
+    - `:memory:` for in-memory (tests)
+    If the DB file does not exist, schema from `app/db/schema.sql` is applied.
+    """
+
+    def __init__(self, storage_url: Optional[str] = None) -> None:
+        # Default to a local file if not provided
+        self.storage_url = storage_url or "data/app.db"
+        self._ensure_db_initialized()
+
+    def _ensure_db_initialized(self) -> None:
+        if self.storage_url != ":memory":
+            db_path = Path(self.storage_url)
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            schema_path = Path(__file__).with_name("schema.sql")
+            with open(schema_path, "r", encoding="utf-8") as f:
+                conn.executescript(f.read())
+
+    @contextmanager
+    def _connect(self):
+        conn = sqlite3.connect(self.storage_url)
+        try:
+            conn.row_factory = sqlite3.Row
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def upsert_mapping(self, mapping: Mapping) -> Mapping:
+        """Insert a new mapping or return existing if linear_issue_id exists.
+
+        Ensures idempotency: same `linear_issue_id` will not create duplicates.
+        """
+        with self._connect() as conn:
+            # Try insert; on conflict return existing stored row
+            cur = conn.execute(
+                """
+                INSERT INTO mappings (linear_issue_id, github_owner, github_repo, github_issue_number, content_checksum)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(linear_issue_id) DO NOTHING;
+                """,
+                (
+                    mapping.linear_issue_id,
+                    mapping.github_owner,
+                    mapping.github_repo,
+                    mapping.github_issue_number,
+                    mapping.content_checksum,
+                ),
+            )
+            # Retrieve row to return canonical data
+            row = conn.execute(
+                "SELECT linear_issue_id, github_owner, github_repo, github_issue_number, content_checksum FROM mappings WHERE linear_issue_id = ?",
+                (mapping.linear_issue_id,),
+            ).fetchone()
+            assert row is not None
+            return Mapping(
+                linear_issue_id=row["linear_issue_id"],
+                github_owner=row["github_owner"],
+                github_repo=row["github_repo"],
+                github_issue_number=int(row["github_issue_number"]),
+                content_checksum=row["content_checksum"],
+            )
+
+    def get_by_linear_issue_id(self, linear_issue_id: str) -> Optional[Mapping]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT linear_issue_id, github_owner, github_repo, github_issue_number, content_checksum FROM mappings WHERE linear_issue_id = ?",
+                (linear_issue_id,),
+            ).fetchone()
+            if not row:
+                return None
+            return Mapping(
+                linear_issue_id=row["linear_issue_id"],
+                github_owner=row["github_owner"],
+                github_repo=row["github_repo"],
+                github_issue_number=int(row["github_issue_number"]),
+                content_checksum=row["content_checksum"],
+            )
+
+    def update_checksum(self, linear_issue_id: str, checksum: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE mappings SET content_checksum = ? WHERE linear_issue_id = ?",
+                (checksum, linear_issue_id),
+            )
+
+    # ---- DLQ operations ----
+    def dlq_insert(self, event_type: str, payload: str, error: str) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "INSERT INTO failed_events (event_type, payload, error) VALUES (?, ?, ?)",
+                (event_type, payload, error),
+            )
+            return int(cur.lastrowid)
+
+    def dlq_list(self):
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT id, event_type, retries, last_seen FROM failed_events ORDER BY last_seen DESC"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def dlq_get(self, id_: int):
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id, event_type, payload, error, retries, first_seen, last_seen FROM failed_events WHERE id = ?",
+                (id_,),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def dlq_bump_retry(self, id_: int, error: str):
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE failed_events SET retries = retries + 1, error = ?, last_seen = CURRENT_TIMESTAMP WHERE id = ?",
+                (error, id_),
+            )
+
+    def dlq_delete(self, id_: int):
+        with self._connect() as conn:
+            conn.execute("DELETE FROM failed_events WHERE id = ?", (id_,))

--- a/app/db/schema.sql
+++ b/app/db/schema.sql
@@ -1,0 +1,26 @@
+-- SQLite schema for idempotent mapping and future DLQ support
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS mappings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  linear_issue_id TEXT NOT NULL UNIQUE,
+  github_owner TEXT NOT NULL,
+  github_repo TEXT NOT NULL,
+  github_issue_number INTEGER NOT NULL,
+  content_checksum TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_mappings_linear_issue_id ON mappings(linear_issue_id);
+
+-- Dead Letter Queue for failed events
+CREATE TABLE IF NOT EXISTS failed_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  error TEXT NOT NULL,
+  retries INTEGER NOT NULL DEFAULT 0,
+  first_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_seen DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from .logging import get_logger
+
+
+async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+    get_logger().warning("http_error", status=exc.status_code, detail=exc.detail)
+    return JSONResponse(status_code=exc.status_code, content={"error": exc.detail})
+
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    get_logger().warning("validation_error", errors=exc.errors())
+    return JSONResponse(status_code=422, content={"error": "validation error"})
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    get_logger().error("unhandled_exception", error=str(exc))
+    return JSONResponse(status_code=500, content={"error": "internal server error"})

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Handlers for Linear events."""

--- a/app/handlers/comment_create.py
+++ b/app/handlers/comment_create.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import HTTPException, Request
+
+from ..db.repository import MappingRepository
+from ..services.github_client import GitHubClient
+from ..config import get_settings
+from ..logging import get_logger
+
+
+def _format_comment(author: str | None, body: str | None) -> str:
+    a = author or "Linear user"
+    b = body or ""
+    return f"From {a} on Linear:\n\n{b}"
+
+
+async def handle_comment_create(payload: Dict[str, Any], request: Request) -> Dict[str, Any]:
+    settings = get_settings()
+    data = payload.get("data", {})
+
+    # Linear comment payloads typically include the parent issue id
+    linear_issue_id = str(data.get("issueId") or data.get("issue") or data.get("issue_id") or "")
+    if not linear_issue_id:
+        # try nested object
+        issue = data.get("issue") or {}
+        linear_issue_id = str(issue.get("id") or issue.get("identifier") or "")
+    if not linear_issue_id:
+        raise HTTPException(status_code=400, detail="missing parent issue id")
+
+    author = (data.get("user") or {}).get("name") if isinstance(data.get("user"), dict) else data.get("user")
+    body = data.get("body") or data.get("text")
+    gh_body = _format_comment(author if isinstance(author, str) else None, body if isinstance(body, str) else None)
+
+    repo: MappingRepository = request.app.state.mapping_repo
+    mapping = repo.get_by_linear_issue_id(linear_issue_id)
+    if not mapping:
+        raise HTTPException(status_code=404, detail="mapping not found")
+
+    log = get_logger().bind(linear_issue_id=linear_issue_id, github_issue_number=mapping.github_issue_number)
+    gh = GitHubClient(token=settings.github_token)
+    try:
+        result = await gh.create_comment(
+            getattr(request.state, "target_owner", mapping.github_owner),
+            getattr(request.state, "target_repo", mapping.github_repo),
+            mapping.github_issue_number,
+            gh_body,
+        )
+    finally:
+        await gh.aclose()
+
+    log.info("comment_created")
+    return {"commented": True, "github_issue_number": mapping.github_issue_number}

--- a/app/handlers/issue_close.py
+++ b/app/handlers/issue_close.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import HTTPException, Request
+
+from ..db.repository import MappingRepository
+from ..services.github_client import GitHubClient
+from ..config import get_settings
+from ..logging import get_logger
+
+
+TERMINAL_STATES = {"Done", "Archived", "Canceled", "Completed"}
+
+
+async def handle_issue_close(payload: Dict[str, Any], request: Request) -> Dict[str, Any]:
+    settings = get_settings()
+    data = payload.get("data", {})
+    linear_issue_id = str(data.get("id") or data.get("identifier") or "")
+    if not linear_issue_id:
+        raise HTTPException(status_code=400, detail="missing issue id in payload")
+
+    # Many Linear payloads carry state name under data.state.name or similar.
+    state = (
+        (data.get("state") or {}).get("name")
+        or data.get("status")
+        or payload.get("state")
+        or ""
+    )
+
+    repo: MappingRepository = request.app.state.mapping_repo
+    mapping = repo.get_by_linear_issue_id(linear_issue_id)
+    if not mapping:
+        raise HTTPException(status_code=404, detail="mapping not found")
+
+    log = get_logger().bind(linear_issue_id=linear_issue_id, github_issue_number=mapping.github_issue_number)
+    gh = GitHubClient(token=settings.github_token)
+    try:
+        result = await gh.update_issue(
+            getattr(request.state, "target_owner", mapping.github_owner),
+            getattr(request.state, "target_repo", mapping.github_repo),
+            mapping.github_issue_number,
+            state="closed",
+        )
+    finally:
+        await gh.aclose()
+
+    log.info("issue_closed", state=state)
+    return {"closed": True, "github_issue_number": mapping.github_issue_number, "state": state}

--- a/app/handlers/issue_create.py
+++ b/app/handlers/issue_create.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import Request
+
+from ..config import get_settings
+from ..db.repository import Mapping, MappingRepository
+from ..services.github_client import GitHubClient
+from ..logging import get_logger
+import hashlib
+
+
+def _format_github_body(linear_issue_id: str, description: str | None) -> str:
+    url = f"https://linear.app/issue/{linear_issue_id}" if linear_issue_id else ""
+    desc = description or ""
+    parts = [desc]
+    if url:
+        parts.append("")
+        parts.append(f"---\nSource: Linear [{linear_issue_id}]({url})")
+    return "\n".join(parts).strip()
+
+
+async def handle_issue_create(payload: Dict[str, Any], request: Request) -> Dict[str, Any]:
+    settings = get_settings()
+
+    data = payload.get("data", {})
+    linear_issue_id = data.get("id") or data.get("identifier") or ""
+    title = data.get("title") or "New issue from Linear"
+    description = data.get("description")
+
+    body = _format_github_body(str(linear_issue_id), description)
+
+    # Resolve target owner/repo (routing rules later); default to settings
+    owner = getattr(request.state, "target_owner", settings.github_owner)
+    repo = getattr(request.state, "target_repo", settings.github_repo)
+
+    # Use app-scoped resources
+    mapping_repo: MappingRepository = request.app.state.mapping_repo
+    log = get_logger().bind(linear_issue_id=linear_issue_id, owner=owner, repo=repo)
+    gh = GitHubClient(token=settings.github_token)
+    try:
+        number = await gh.create_issue(owner, repo, title, body=body, labels=["source:linear"])  # type: ignore[arg-type]
+    finally:
+        await gh.aclose()
+
+    checksum = hashlib.sha256(f"{title}\n\n{body}".encode("utf-8")).hexdigest()
+    mapping = Mapping(
+        linear_issue_id=str(linear_issue_id),
+        github_owner=owner,
+        github_repo=repo,
+        github_issue_number=number,
+        content_checksum=checksum,
+    )
+    stored = mapping_repo.upsert_mapping(mapping)
+    log.info("issue_created_and_mapped", github_issue_number=stored.github_issue_number)
+    return {"github_issue_number": stored.github_issue_number}

--- a/app/handlers/issue_update.py
+++ b/app/handlers/issue_update.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException, Request
+
+from ..db.repository import MappingRepository
+from ..services.github_client import GitHubClient
+from ..config import get_settings
+from ..logging import get_logger
+import hashlib
+
+
+async def handle_issue_update(payload: Dict[str, Any], request: Request) -> Dict[str, Any]:
+    settings = get_settings()
+    data = payload.get("data", {})
+    linear_issue_id = str(data.get("id") or data.get("identifier") or "")
+    if not linear_issue_id:
+        raise HTTPException(status_code=400, detail="missing issue id in payload")
+
+    title: Optional[str] = data.get("title")
+    description: Optional[str] = data.get("description")
+
+    repo: MappingRepository = request.app.state.mapping_repo
+    mapping = repo.get_by_linear_issue_id(linear_issue_id)
+    if not mapping:
+        raise HTTPException(status_code=404, detail="mapping not found")
+
+    log = get_logger().bind(linear_issue_id=linear_issue_id, github_issue_number=mapping.github_issue_number)
+    # Compute prospective checksum and skip if unchanged
+    prospective_body = description if description is not None else ""
+    prospective_title = title if title is not None else ""
+    new_checksum = hashlib.sha256(f"{prospective_title}\n\n{prospective_body}".encode("utf-8")).hexdigest()
+    if mapping.content_checksum == new_checksum:
+        log.info("skip_update_noop")
+        return {"updated": False, "github_issue_number": mapping.github_issue_number, "skipped": True}
+
+    gh = GitHubClient(token=settings.github_token)
+    try:
+        result = await gh.update_issue(
+            getattr(request.state, "target_owner", mapping.github_owner),
+            getattr(request.state, "target_repo", mapping.github_repo),
+            mapping.github_issue_number,
+            title=title,
+            body=description,
+        )
+    finally:
+        await gh.aclose()
+    # Update checksum after success
+    repo.update_checksum(linear_issue_id, new_checksum)
+    log.info("issue_updated")
+    return {"updated": True, "github_issue_number": mapping.github_issue_number}

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+import sys
+import uuid
+from contextvars import ContextVar
+
+import structlog
+from fastapi import Request
+
+
+request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+def get_request_id() -> str | None:
+    return request_id_ctx.get()
+
+
+def set_request_id(value: str | None) -> None:
+    request_id_ctx.set(value)
+
+
+def configure_logging(level: str = "INFO") -> None:
+    logging.basicConfig(format="%(message)s", stream=sys.stdout, level=level)
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(getattr(logging, level.upper(), logging.INFO)),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger():
+    return structlog.get_logger()
+
+
+async def request_id_middleware(request: Request, call_next):
+    rid = request.headers.get("x-request-id") or str(uuid.uuid4())
+    set_request_id(rid)
+    structlog.contextvars.bind_contextvars(request_id=rid, path=request.url.path, method=request.method)
+    try:
+        response = await call_next(request)
+    finally:
+        # Clear context to avoid leakage across requests
+        structlog.contextvars.clear_contextvars()
+        set_request_id(None)
+    response.headers["x-request-id"] = rid
+    return response

--- a/app/router/__init__.py
+++ b/app/router/__init__.py
@@ -1,0 +1,1 @@
+"""Event router package."""

--- a/app/router/events.py
+++ b/app/router/events.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+
+def parse_linear_event(payload: Dict[str, Any]) -> Tuple[str, str]:
+    """Return (entity, action) for a Linear webhook payload.
+
+    Linear delivers e.g. { "type": "Issue", "action": "create", ... }
+    Fallbacks ensure router doesn't crash on unexpected shapes.
+    """
+    entity = str(payload.get("type") or payload.get("entity") or "unknown")
+    action = str(payload.get("action") or payload.get("event") or "unknown")
+    return entity, action

--- a/app/routing.py
+++ b/app/routing.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple, List
+
+
+def resolve_repo(payload: Dict[str, Any], rules: List[Dict[str, Any]], default: Tuple[str, str]) -> Tuple[str, str]:
+    data = payload.get("data", {}) if isinstance(payload, dict) else {}
+    # Extract common attributes
+    team_id = data.get("teamId") or (data.get("team") or {}).get("id")
+    labels = {l.get("name") for l in (data.get("labels") or []) if isinstance(l, dict)}
+    project_id = data.get("projectId") or (data.get("project") or {}).get("id")
+
+    for rule in rules:
+        target = rule.get("target")
+        if not target or "/" not in target:
+            continue
+        # Matchers: any provided must match
+        ok = True
+        if "teamId" in rule:
+            ok = ok and rule["teamId"] == team_id
+        if ok and "projectId" in rule:
+            ok = ok and rule["projectId"] == project_id
+        if ok and "label" in rule:
+            ok = ok and (rule["label"] in labels if labels else False)
+        if ok and "labelsAny" in rule:
+            wanted = set(rule["labelsAny"]) if isinstance(rule["labelsAny"], list) else set()
+            ok = ok and bool(labels and (labels & wanted))
+        if ok:
+            owner, repo = target.split("/", 1)
+            return owner, repo
+    return default

--- a/app/services/github_client.py
+++ b/app/services/github_client.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt, wait_exponential, RetryCallState
+
+
+GITHUB_API = "https://api.github.com"
+
+
+@dataclass
+class GitHubClient:
+    token: str
+    base_url: str = GITHUB_API
+    client: Optional[httpx.AsyncClient] = None
+    user_agent: str = "linear-webhooks-router/0.1"
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": self.user_agent,
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _ensure_client(self) -> httpx.AsyncClient:
+        if self.client is None:
+            self.client = httpx.AsyncClient(base_url=self.base_url, timeout=20.0)
+        return self.client
+
+    async def aclose(self) -> None:
+        if self.client is not None:
+            await self.client.aclose()
+            self.client = None
+
+    def _retryable(exc: BaseException) -> bool:  # type: ignore[no-redef]
+        if isinstance(exc, httpx.HTTPStatusError):
+            status = exc.response.status_code
+            return status >= 500 or status == 429
+        if isinstance(exc, httpx.TransportError):
+            return True
+        return False
+
+    async def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        client = self._ensure_client()
+        headers = kwargs.pop("headers", {})
+        headers = {**self._headers(), **headers}
+        last_resp: Optional[httpx.Response] = None
+        async for attempt in AsyncRetrying(
+            stop=stop_after_attempt(5),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=8),
+            retry=retry_if_exception(self._retryable),
+            reraise=True,
+        ):
+            with attempt:
+                resp = await client.request(method, url, headers=headers, **kwargs)
+                last_resp = resp
+                if resp.status_code >= 400:
+                    # Honor Retry-After for 429/5xx if present (tenacity handles waits between attempts)
+                    try:
+                        resp.raise_for_status()
+                    except httpx.HTTPStatusError as e:
+                        raise
+                # success
+        assert last_resp is not None
+        rl = {
+            k: last_resp.headers.get(k)
+            for k in ("X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset")
+        }
+        last_resp._rate_limit = rl  # type: ignore[attr-defined]
+        return last_resp
+
+    # --- Issues & Comments ---
+    async def create_issue(self, owner: str, repo: str, title: str, body: Optional[str] = None, labels: Optional[list[str]] = None) -> int:
+        payload: Dict[str, Any] = {"title": title}
+        if body is not None:
+            payload["body"] = body
+        if labels:
+            payload["labels"] = labels
+        resp = await self._request("POST", f"/repos/{owner}/{repo}/issues", json=payload)
+        data = resp.json()
+        return int(data["number"])  # issue number
+
+    async def update_issue(self, owner: str, repo: str, number: int, *, title: Optional[str] = None, body: Optional[str] = None, state: Optional[str] = None) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        if title is not None:
+            payload["title"] = title
+        if body is not None:
+            payload["body"] = body
+        if state is not None:
+            payload["state"] = state
+        resp = await self._request("PATCH", f"/repos/{owner}/{repo}/issues/{number}", json=payload)
+        return resp.json()
+
+    async def create_comment(self, owner: str, repo: str, number: int, body: str) -> Dict[str, Any]:
+        payload = {"body": body}
+        resp = await self._request("POST", f"/repos/{owner}/{repo}/issues/{number}/comments", json=payload)
+        return resp.json()


### PR DESCRIPTION
This PR delivers an end-to-end MVP for a Linear → GitHub webhook bridge.

Highlights
- Signature verification for Linear webhooks
- Event router with handlers: issue.create, issue.update, issue.close, comment.create
- SQLite mapping store (idempotent upsert) + checksum to skip no-op updates
- GitHub API client (httpx) with retries/backoff (tenacity) and `Retry-After` support
- Structured JSON logging (structlog) and request ID middleware
- Global exception handlers with sanitized JSON errors
- Dead-Letter Queue (DLQ) for failed events + CLI to list/view/replay
- Multi-repo routing via `ROUTING_RULES_JSON` rules (team/project/labels)
- README instructions and a `scripts/smoke_test.py` for local testing
- Test suite with respx for GitHub mocks

How to run
1) Using uv:
- `uv venv`
- `uv pip install -r requirements.txt`
- `cp .env.example .env` and fill secrets
- `uv run uvicorn app.main:app --host 0.0.0.0 --port 8000`
- `uv run python scripts/smoke_test.py --event issue.create`

2) Using pip:
- `python -m venv .venv && source .venv/bin/activate` (or `.venv\\Scripts\\activate` on Windows)
- `pip install -r requirements.txt`
- `uvicorn app.main:app --host 0.0.0.0 --port 8000`

Env vars
- `GITHUB_OWNER`, `GITHUB_REPO`, `GITHUB_TOKEN`, `LINEAR_WEBHOOK_SECRET`
- Optional: `LOG_LEVEL`, `STORAGE_URL`, `ROUTING_RULES_JSON`

Notes
- Mapping store checksum prevents unnecessary PATCH calls on updates.
- DLQ captures handler failures and supports replay via CLI.
- Routing falls back to the configured default repo when no rule matches.
